### PR TITLE
Docker image with curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:focal
+
+# Install required system packages for our CronJobs
+RUN apt-get update && apt-get install --yes curl


### PR DESCRIPTION
# Done

Basic docker image to start using CronJobs with the webbot. The only dependency is curl right now.

# QA
- Checkout this branch
- Run: `docker build . --tag test`